### PR TITLE
Explicitly set `pix_scale` in `GalSim` functions

### DIFF
--- a/kl_tools/intensity.py
+++ b/kl_tools/intensity.py
@@ -201,7 +201,8 @@ class InclinedExponential(IntensityMap):
             psf = pars['psf']
             gal = gs.Convolve([gal, psf])
 
-        self.image = gal.drawImage(nx=self.nx, ny=self.ny).array
+        pixscale = pars['pix_scale']
+        self.image = gal.drawImage(nx=self.nx, ny=self.ny, scale=pixscale).array
 
         return self.image
 

--- a/kl_tools/likelihood.py
+++ b/kl_tools/likelihood.py
@@ -428,7 +428,7 @@ def _setup_test_datacube(shape, lambdas, bandpasses, sed, true_pars, pars):
             lambdas[i], sed_array, zfactor, true_im
             )
 
-        obs_im = gs.Image(obs_array)
+        obs_im = gs.Image(obs_array, scale=pars['pix_scale'])
 
         noise = gs.GaussianNoise(sigma=pars['cov_sigma'])
         obs_im.addNoise(noise)

--- a/kl_tools/likelihood.py
+++ b/kl_tools/likelihood.py
@@ -106,9 +106,18 @@ def log_likelihood(theta, datacube, pars):
     Do setup and type / sanity checking here
     before calling _loglikelihood
 
-    theta: Parameters sampled by zeus. Order defined in PARS_ORDER
-    datacube: DataCube object, truncated to desired lambda bounds
-    pars: Dict of any other parameters needed to evaluate likelihood
+    theta: list
+        Sampled parameters. Order defined in PARS_ORDER
+    datacube: DataCube
+        Truncated to desired lambda bounds
+    pars: dict
+        Dictionary of any other parameters needed to evaluate likelihood
+
+    TODO: Would be nice to swap datacube for the following:
+    datavector: DataCube, numpy.array, etc.
+        Arbitrary data vector. Likely a datacube truncated
+        to relevant emission line slices
+
     '''
 
     # unpack sampled zeus params
@@ -180,8 +189,6 @@ def _log_likelihood(datacube, lambdas, vmap, imap, sed, inv_cov):
     '''
     datacube: The (Nx,Ny,Nspec) data array of a DataCube object,
                 truncated to desired lambda bounds
-    # lambdas: Wavelength values at the center of each datacube
-    #             slice
     lambdas: List of lambda tuples that define slice edges
     vmap: An (Nx,Ny) array of normalized (by c) velocity values in the
             obs plane returned by a call from a VelocityMap object
@@ -428,9 +435,6 @@ def _setup_test_datacube(shape, lambdas, bandpasses, sed, true_pars, pars):
 
         data[:,:,i] = obs_im.array
 
-    # TODO: testing!
-    # stack = np.sum(data, axis=2)
-    # pudb.set_trace()
     datacube = DataCube(data=data, bandpasses=bandpasses)
 
     return datacube, V, true_im

--- a/kl_tools/test_alt_likelihood_by_param.py
+++ b/kl_tools/test_alt_likelihood_by_param.py
@@ -27,7 +27,8 @@ def main(args):
     true_pars = {
         'g1': 0.05,
         'g2': -0.025,
-        'theta_int': np.pi / 3,
+        # 'theta_int': np.pi / 3,
+        'theta_int': 0.,
         'sini': 0.8,
         'v0': 10.,
         'vcirc': 200,
@@ -41,6 +42,7 @@ def main(args):
     pars = {
         'Nx': 30, # pixels
         'Ny': 30, # pixels
+        'pix_scale': 1, # arcsec / pix
         'true_flux': 1e5, # counts
         'true_hlr': 5, # pixels
         'v_unit': Unit('km / s'),
@@ -190,14 +192,27 @@ def main(args):
 
     # These are centered at an alt solution,
     # using correct intensity map (cov_sig=1)
+    # alt_pars = {
+    #     'g1': -0.0255,
+    #     'g2': 0.1082,
+    #     'theta_int': 1.0437,
+    #     'sini': 0.5724,
+    #     'v0': 10.0144,
+    #     'vcirc': 278.4138,
+    #     'rscale': 4.2491,
+    #     }
+
+    # These are centered at an alt soltuion for theta_int=0,
+    # using correct intensty map (cov_sig=1)
+    # true_pars['theta_int'] = 0
     alt_pars = {
-        'g1': -0.0255,
-        'g2': 0.1082,
-        'theta_int': 1.0437,
-        'sini': 0.5724,
-        'v0': 10.0144,
-        'vcirc': 278.4138,
-        'rscale': 4.2491,
+        'g1': -0.0230,
+        'g2': -0.0249,
+        'theta_int': 0.0019,
+        'sini': 0.8560,
+        'v0': 10.0169,
+        'vcirc': 187.6312,
+        'rscale': 5.4146,
         }
 
     size = (14,5)

--- a/kl_tools/test_compare_alt_solution.py
+++ b/kl_tools/test_compare_alt_solution.py
@@ -45,6 +45,7 @@ def main(args):
     pars = {
         'Nx': 30, # pixels
         'Ny': 30, # pixels
+        'pix_scale': 1, # arcsec / pix
         'true_flux': 1e5, # counts
         'true_hlr': 5, # pixels
         'v_unit': Unit('km / s'),


### PR DESCRIPTION
For quick tests, thought that keeping `pixel_scale=1` would eliminate possible issues with missing factors. However the defaults have changed, so this needs to be set explicitly even for a value of 1.